### PR TITLE
Added code to remove brackets in file name

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,1 +1,2 @@
 exports.port = 13579
+exports.ignoreBrackets = true

--- a/core.js
+++ b/core.js
@@ -1,5 +1,6 @@
 const log = require('fancy-log'),
     jsdom = require('jsdom'),
+    config = require('./config'),
     { JSDOM } = jsdom;
 
 // Discord Rich Presence has a string length limit of 128 characters.
@@ -19,6 +20,8 @@ let playback = {
     prevState: '',
     prevPosition: '',
 };
+
+const ignoreBrackets = config.ignoreBrackets;
 
 // Defines strings and image keys according to the 'state' string
 // provided by MPC.
@@ -55,6 +58,7 @@ const updatePresence = (res, rpc) => {
 
     // Gets relevant info from the DOM object.
     playback.filename = document.getElementById('filepath').textContent.split("\\").pop().trimStr(128);
+    if (ignoreBrackets) playback.filename = playback.filename.replace(/ *\[[^)]*\] */g, "").trimStr(128);
     playback.state = document.getElementById('state').textContent;
     playback.duration = sanitizeTime(document.getElementById('durationstring').textContent);
     playback.position = sanitizeTime(document.getElementById('positionstring').textContent);

--- a/core.js
+++ b/core.js
@@ -58,7 +58,7 @@ const updatePresence = (res, rpc) => {
 
     // Gets relevant info from the DOM object.
     playback.filename = document.getElementById('filepath').textContent.split("\\").pop().trimStr(128);
-    if (ignoreBrackets) playback.filename = playback.filename.replace(/ *\[[^)]*\] */g, "").trimStr(128);
+    if (ignoreBrackets) playback.filename = playback.filename.replace(/ *\[[^\]]*\] */g, "").trimStr(128);
     playback.state = document.getElementById('state').textContent;
     playback.duration = sanitizeTime(document.getElementById('durationstring').textContent);
     playback.position = sanitizeTime(document.getElementById('positionstring').textContent);

--- a/core.js
+++ b/core.js
@@ -58,7 +58,7 @@ const updatePresence = (res, rpc) => {
 
     // Gets relevant info from the DOM object.
     playback.filename = document.getElementById('filepath').textContent.split("\\").pop().trimStr(128);
-    if (ignoreBrackets) playback.filename = playback.filename.replace(/ *\[[^\]]*\] */g, "").trimStr(128);
+    if (ignoreBrackets) playback.filename = playback.filename.replace(/ *\[[^\]]*\]/g, "").trimStr(128);
     playback.state = document.getElementById('state').textContent;
     playback.duration = sanitizeTime(document.getElementById('durationstring').textContent);
     playback.position = sanitizeTime(document.getElementById('positionstring').textContent);


### PR DESCRIPTION
If you are watching movies or other stuff with info in file names such as [1080p], [Translation Group Name] and you want to get rid of it, with this update you can use new config line "exports.ignoreBrackets = true" and all brackets and their content will disappear.

It only removes [ ] and everything between them. It will keep ( ) and other brackets.

I just wanted to add a way to switch it ON and OFF since some people might want to keep the brackets so I added new config line called ignoreBrackets that is boolean type. I added ./config as required in core.js and it's reading the ignoreBracket setting in the same way and in the same place as index.js is reading the port.

I wasn't sure how to do the replace part, so you might keep it as it is or change it to

if (ignoreBrackets) playback.filename = document.getElementById('filepath').textContent.split("\\").pop().replace(/ *\[[^)]*\] */g, "").trimStr(128);
else playback.filename = document.getElementById('filepath').textContent.split("\\").pop().trimStr(128);

edit: fixed regex, was pretty tired last night and didn't have a chance to test it fully...