### PR TITLE
More options - ignore filetype, replace underscore

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ Default: `true`
 
 Whether to omit brackets `[]` and its content in filenames. Useful if you don't want to show on your profile those info tags that usually comes inside brackets in filenames, like `[1080p]`, `[Translator Group Name]`, etc. You can set it to `false` or remove this line to turn off this behavior.
 
+#### `exports.ignoreFiletype`
+Default: `false`
+
+Whether to omit filetype. Useful if you don't want to show on your profile the type of the file that is currently open, for example `.mp4`, `.mkv`, `.flac`. You can set it to `true` to turn on this behavior.
+
+#### `exports.replaceUnderscore`
+Default: `true`
+
+Whether to omit replace `_` with space. Useful if you have files like `Your_Favourite_Movie`. You can set it to `false` or remove this line to turn off this behavior.
+
 #### `exports.showRemainingTime`
 Default: `false`
 

--- a/config.js
+++ b/config.js
@@ -1,3 +1,5 @@
 exports.port = 13579
 exports.ignoreBrackets = true
+exports.ignoreFiletype = false
+exports.replaceUnderscore = true
 exports.showRemainingTime = false

--- a/core.js
+++ b/core.js
@@ -1,6 +1,6 @@
 const log = require('fancy-log'),
     jsdom = require('jsdom'),
-    { ignoreBrackets, showRemainingTime } = require('./config'),
+    { ignoreBrackets, ignoreFiletype, replaceUnderscore, showRemainingTime } = require('./config'),
     { JSDOM } = jsdom;
 
 // Discord Rich Presence has a string length limit of 128 characters.
@@ -60,11 +60,18 @@ const updatePresence = (res, rpc) => {
     playback.duration = sanitizeTime(document.getElementById('durationstring').textContent);
     playback.position = sanitizeTime(document.getElementById('positionstring').textContent);
 
-    // Removes brackets and its content from filename if `ignoreBrackets` option
-    // is set to true
+    // Replaces underscore characters to space characters
+    if (replaceUnderscore) playback.filename = playback.filename.replace(/_/g, " ");
+
+	// Removes brackets and its content from filename if `ignoreBrackets` option
+	// is set to true
     if (ignoreBrackets) {
         playback.filename = playback.filename.replace(/ *\[[^\]]*\]/g, "").trimStr(128);
+        if (playback.filename.substr(0, playback.filename.lastIndexOf(".")).length == 0) playback.filename = document.getElementById('filepath').textContent.split("\\").pop().trimStr(128);
     }
+	
+	// Removes filetype from displaying
+	if (ignoreFiletype) playback.filename = playback.filename.substr(0, playback.filename.lastIndexOf("."));
 
     // Prepares playback data for Discord Rich Presence.
     let payload = {

--- a/core.js
+++ b/core.js
@@ -55,7 +55,7 @@ const updatePresence = (res, rpc) => {
     const { document } = new JSDOM(res.body).window;
 
     // Gets relevant info from the DOM object.
-    playback.filename = document.getElementById('filepath').textContent.split("\\").pop().trimStr(128);
+    playback.filename = document.getElementById('file').textContent.trimStr(128);
     playback.state = document.getElementById('state').textContent;
     playback.duration = sanitizeTime(document.getElementById('durationstring').textContent);
     playback.position = sanitizeTime(document.getElementById('positionstring').textContent);
@@ -67,7 +67,7 @@ const updatePresence = (res, rpc) => {
 	// is set to true
     if (ignoreBrackets) {
         playback.filename = playback.filename.replace(/ *\[[^\]]*\]/g, "").trimStr(128);
-        if (playback.filename.substr(0, playback.filename.lastIndexOf(".")).length == 0) playback.filename = document.getElementById('filepath').textContent.split("\\").pop().trimStr(128);
+        if (playback.filename.substr(0, playback.filename.lastIndexOf(".")).length == 0) playback.filename = document.getElementById('file').textContent.trimStr(128);
     }
 	
 	// Removes filetype from displaying


### PR DESCRIPTION
Hey, I wrote a lot of text before and it got deleted, so I'm not gonna write it all once again.

I added ignoreFiletype and replaceUnderscore. Also when there is nothing remaining after removing brackets (if file name is in brackets only), it will revert filename to the original and keep brackets.

I also noticed that you do

`document.getElementById('filepath').textContent.split("\\").pop()`

but we could do

`document.getElementById('file').textContent`

Is there any specific reason you rae using "filepath" instead of "file"? If no, this would save us some code and operations.

And of course, if you see something not done properly or not the way you would do it or prefer it, feel free to edit and make the changes.

Edit: Forgot to mention, ignore filetype is set to false as default and replace underscore to true as default.

The code first replaces the underscore then checks brackets and then checks filetype, which is probably the best way. I also noticed typo that I did editing readme under "replace underscore" section: "Whether to omit replace" - but I will leave readme for you to tune yourself.